### PR TITLE
Deployed login authorization

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify, g
+from flask import Blueprint, request, jsonify, g, current_app
 from flask_jwt_extended import create_access_token
 from models import db, User
 from logging_config import get_logger
@@ -10,9 +10,13 @@ import os
 from werkzeug.security import check_password_hash as check_legacy_password_hash
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
-from auth_identity import AuthIdentityConflictError, MissingIdentityEmailError, sync_managed_user
+from auth_identity import (
+    AuthIdentityConflictError,
+    MissingIdentityEmailError,
+    get_external_auth_identity_from_claims,
+    sync_managed_user,
+)
 from routes import (
-    get_external_auth_identity_for_token,
     supabase_jwt_required,
     get_supabase_claims,
     get_supabase_claims_for_token,
@@ -178,21 +182,34 @@ def _normalize_auth0_text(value):
     return ''
 
 
+def _auth0_config_value(key):
+    value = None
+    try:
+        value = current_app.config.get(key)
+    except RuntimeError:
+        value = None
+
+    if value is None:
+        value = os.getenv(key)
+
+    return _normalize_auth0_text(value)
+
+
 def _normalize_frontend_redirect_uri(override_redirect_uri=''):
     if isinstance(override_redirect_uri, str):
         override = override_redirect_uri.strip()
         if override:
             return override
 
-    configured_redirect_uri = _normalize_auth0_text(os.getenv('AUTH0_REDIRECT_URI'))
+    configured_redirect_uri = _auth0_config_value('AUTH0_REDIRECT_URI')
     if configured_redirect_uri:
         return configured_redirect_uri
 
-    vite_redirect_uri = _normalize_auth0_text(os.getenv('VITE_AUTH0_REDIRECT_URI'))
+    vite_redirect_uri = _auth0_config_value('VITE_AUTH0_REDIRECT_URI')
     if vite_redirect_uri:
         return vite_redirect_uri
 
-    frontend_url = _normalize_auth0_text(os.getenv('FRONTEND_URL'))
+    frontend_url = _auth0_config_value('FRONTEND_URL')
     if frontend_url:
         return f'{frontend_url.rstrip("/")}/auth/callback'
 
@@ -200,7 +217,7 @@ def _normalize_frontend_redirect_uri(override_redirect_uri=''):
 
 
 def _build_auth0_token_url():
-    raw_domain = _normalize_auth0_text(os.getenv('AUTH0_DOMAIN'))
+    raw_domain = _auth0_config_value('AUTH0_DOMAIN')
     if not raw_domain:
         return ''
 
@@ -209,6 +226,18 @@ def _build_auth0_token_url():
         normalized_domain = f'https://{normalized_domain}'
 
     return f'{normalized_domain}/oauth/token'
+
+
+def _build_auth0_userinfo_url():
+    raw_domain = _auth0_config_value('AUTH0_DOMAIN')
+    if not raw_domain:
+        return ''
+
+    normalized_domain = raw_domain.rstrip('/')
+    if not normalized_domain.startswith(('http://', 'https://')):
+        normalized_domain = f'https://{normalized_domain}'
+
+    return f'{normalized_domain}/userinfo'
 
 
 def _extract_json_error_message(raw_body):
@@ -237,12 +266,98 @@ def _extract_json_error_message(raw_body):
     return raw_body
 
 
+def _extract_json_payload(raw_body):
+    if not isinstance(raw_body, str):
+        return None
+
+    raw_body = raw_body.strip()
+    if not raw_body:
+        return None
+
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError:
+        return None
+
+    return payload if isinstance(payload, dict) else None
+
+
+def _fetch_auth0_userinfo(access_token):
+    userinfo_url = _build_auth0_userinfo_url()
+    if not userinfo_url:
+        return None, 'Auth0 domain is not configured for userinfo lookup.'
+
+    normalized_token = _normalize_auth0_text(access_token)
+    if not normalized_token:
+        return None, 'Access token is required for userinfo lookup.'
+
+    request = Request(
+        userinfo_url,
+        method='GET',
+        headers={
+            'Accept': 'application/json',
+            'Authorization': f'Bearer {normalized_token}',
+        },
+    )
+
+    try:
+        with urlopen(request, timeout=10) as response:
+            response_body = response.read().decode('utf-8')
+    except HTTPError as error:
+        try:
+            raw_error = error.read().decode('utf-8', errors='replace')
+        except Exception:
+            raw_error = ''
+
+        error_message = _extract_json_error_message(raw_error) or str(error)
+        return None, f'Auth0 userinfo lookup failed: {error_message}'
+    except URLError as error:
+        return None, f'Unable to reach Auth0 userinfo endpoint: {error}'
+    except Exception as error:
+        return None, f'Auth0 userinfo lookup failed: {error}'
+
+    payload = _extract_json_payload(response_body)
+    if payload is None:
+        return None, 'Auth0 userinfo endpoint returned an invalid response.'
+
+    return payload, ''
+
+
+def _is_verified_auth0_claims(claims):
+    if not isinstance(claims, dict):
+        return False
+
+    if not claims.get('iss') or not claims.get('aud'):
+        return False
+
+    identity = get_external_auth_identity_from_claims(claims)
+    return bool(identity and identity.get('provider') == 'auth0' and identity.get('subject'))
+
+
+def _merge_auth0_claims(decoded_claims=None, userinfo_claims=None):
+    merged = {}
+
+    if isinstance(userinfo_claims, dict):
+        merged.update(userinfo_claims)
+
+    if isinstance(decoded_claims, dict):
+        for key, value in decoded_claims.items():
+            if isinstance(value, dict) and isinstance(merged.get(key), dict):
+                merged[key] = {**merged[key], **value}
+                continue
+
+            if value not in (None, ''):
+                merged[key] = value
+
+    return merged
+
+
 def _exchange_authorization_code_for_access_token(auth_code, code_verifier, redirect_uri):
     token_url = _build_auth0_token_url()
     if not token_url:
         return '', 'Auth0 domain is not configured for token exchange.'
 
-    client_id = _normalize_auth0_text(os.getenv('AUTH0_CLIENT_ID'))
+    client_id = _auth0_config_value('AUTH0_CLIENT_ID')
     if not client_id:
         return '', 'Auth0 client_id is not configured for token exchange.'
 
@@ -597,21 +712,26 @@ def exchange():
             'code': 'AUTH0_ACCESS_TOKEN_REQUIRED',
         }), 400
 
+    decoded_claims = None
     try:
-        claims = get_supabase_claims_for_token(auth0_access_token, optional=False)
-        if not isinstance(claims, dict) or not claims.get('iss') or not claims.get('aud'):
-            return jsonify({
-                'error': 'Invalid access token',
-                'code': 'AUTH0_INVALID_ACCESS_TOKEN',
-            }), 401
+        candidate_claims = get_supabase_claims_for_token(auth0_access_token, optional=False)
+        if _is_verified_auth0_claims(candidate_claims):
+            decoded_claims = candidate_claims
     except Exception:
-        return jsonify({
-            'error': 'Unauthorized',
-            'code': 'AUTH0_TOKEN_UNAUTHORIZED',
-        }), 401
+        decoded_claims = None
 
-    auth_identity = get_external_auth_identity_for_token(auth0_access_token)
-    if not auth_identity:
+    userinfo_claims = None
+    if decoded_claims is None or not decoded_claims.get('email'):
+        userinfo_claims, _userinfo_error = _fetch_auth0_userinfo(auth0_access_token)
+        if decoded_claims is None and not isinstance(userinfo_claims, dict):
+            return jsonify({
+                'error': 'Unauthorized',
+                'code': 'AUTH0_TOKEN_UNAUTHORIZED',
+            }), 401
+
+    claims = _merge_auth0_claims(decoded_claims, userinfo_claims)
+    auth_identity = get_external_auth_identity_from_claims(claims)
+    if not auth_identity or auth_identity.get('provider') != 'auth0':
         return jsonify({
             'error': 'Invalid access token',
             'code': 'AUTH0_INVALID_ACCESS_TOKEN',

--- a/backend/tests/test_auth_identity.py
+++ b/backend/tests/test_auth_identity.py
@@ -1,4 +1,11 @@
+from datetime import datetime, timedelta, timezone
+import json
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 import jwt
+import routes
+from routes import auth as auth_routes
 
 from app import app
 from models import User
@@ -6,6 +13,67 @@ from models import User
 
 def _build_token(claims):
     return jwt.encode(claims, app.config['SUPABASE_JWT_SECRET'], algorithm='HS256')
+
+
+class _FakeSigningKey:
+    def __init__(self, key):
+        self.key = key
+
+
+class _FakeJwksClient:
+    def __init__(self, key):
+        self._key = key
+
+    def get_signing_key_from_jwt(self, token):
+        return _FakeSigningKey(self._key)
+
+
+class _FakeUrlopenResponse:
+    def __init__(self, payload):
+        self._payload = json.dumps(payload).encode('utf-8')
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _build_auth0_keys():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _build_auth0_token(private_key, *, sub, domain, audience, email=None):
+    now = datetime.now(timezone.utc)
+    claims = {
+        'sub': sub,
+        'iss': f'https://{domain}/',
+        'aud': audience,
+        'iat': int(now.timestamp()),
+        'exp': int((now + timedelta(minutes=10)).timestamp()),
+    }
+    if email:
+        claims['email'] = email
+
+    return jwt.encode(
+        claims,
+        private_key,
+        algorithm='RS256',
+        headers={'kid': 'test-key'},
+    )
 
 
 def test_sync_creates_internal_user_id_for_supabase_subject(client):
@@ -73,5 +141,85 @@ def test_exchange_creates_internal_user_id_for_auth0_subject(client):
         user = User.query.filter_by(email='auth0-user@example.com').first()
         assert user is not None
         assert user.id == exchanged_user['id']
+        assert user.auth_provider == 'auth0'
+        assert user.auth_subject == external_subject
+
+
+def test_exchange_uses_auth0_userinfo_when_verified_token_omits_email(client, monkeypatch):
+    auth0_domain = 'litmusai-test.us.auth0.com'
+    auth0_audience = 'https://api.example.test'
+    external_subject = 'auth0|userinfo-email-fallback'
+    private_key, public_key = _build_auth0_keys()
+    token = _build_auth0_token(
+        private_key,
+        sub=external_subject,
+        domain=auth0_domain,
+        audience=auth0_audience,
+    )
+
+    monkeypatch.setitem(app.config, 'AUTH0_DOMAIN', auth0_domain)
+    monkeypatch.setitem(app.config, 'AUTH0_AUDIENCE', auth0_audience)
+    monkeypatch.setattr(routes, '_get_auth0_jwks_client', lambda domain: _FakeJwksClient(public_key))
+
+    def fake_urlopen(request, timeout=10):
+        assert request.full_url == f'https://{auth0_domain}/userinfo'
+        return _FakeUrlopenResponse({
+            'sub': external_subject,
+            'email': 'userinfo-fallback@example.com',
+            'given_name': 'Userinfo',
+            'family_name': 'Fallback',
+        })
+
+    monkeypatch.setattr(auth_routes, 'urlopen', fake_urlopen)
+
+    response = client.post(
+        '/api/auth/exchange',
+        json={'access_token': token},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload['user']['email'] == 'userinfo-fallback@example.com'
+
+    with app.app_context():
+        user = User.query.filter_by(email='userinfo-fallback@example.com').first()
+        assert user is not None
+        assert user.auth_provider == 'auth0'
+        assert user.auth_subject == external_subject
+
+
+def test_exchange_accepts_auth0_userinfo_when_token_is_not_locally_decodable(client, monkeypatch):
+    auth0_domain = 'litmusai-test.us.auth0.com'
+    auth0_audience = 'https://api.example.test'
+    external_subject = 'auth0|opaque-userinfo-fallback'
+    opaque_token = 'opaque-auth0-access-token'
+
+    monkeypatch.setitem(app.config, 'AUTH0_DOMAIN', auth0_domain)
+    monkeypatch.setitem(app.config, 'AUTH0_AUDIENCE', auth0_audience)
+    monkeypatch.setattr(routes, '_get_auth0_jwks_client', lambda domain: None)
+
+    def fake_urlopen(request, timeout=10):
+        assert request.full_url == f'https://{auth0_domain}/userinfo'
+        return _FakeUrlopenResponse({
+            'sub': external_subject,
+            'email': 'opaque-userinfo@example.com',
+            'given_name': 'Opaque',
+            'family_name': 'Token',
+        })
+
+    monkeypatch.setattr(auth_routes, 'urlopen', fake_urlopen)
+
+    response = client.post(
+        '/api/auth/exchange',
+        json={'access_token': opaque_token},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload['user']['email'] == 'opaque-userinfo@example.com'
+
+    with app.app_context():
+        user = User.query.filter_by(email='opaque-userinfo@example.com').first()
+        assert user is not None
         assert user.auth_provider == 'auth0'
         assert user.auth_subject == external_subject


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix deployed Auth0 login exchange by falling back to `/userinfo` for user identity when access tokens lack full profile claims.

The deployed login flow was failing with 401 Unauthorized because the backend's `/api/auth/exchange` endpoint incorrectly assumed that Auth0 access tokens would always contain full user profile claims (like `email`) or be locally decodable. This PR introduces a fallback to Auth0's `/userinfo` endpoint to reliably retrieve user identity, ensuring compatibility with various Auth0 token payloads.

---
<p><a href="https://cursor.com/agents/bc-7ca35918-6cdc-4fe6-93fd-de4268feecb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ca35918-6cdc-4fe6-93fd-de4268feecb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->